### PR TITLE
Fix double paste in webviews (1.47 recovery)

### DIFF
--- a/contribution.ts
+++ b/contribution.ts
@@ -1,0 +1,1 @@
+//Fix double clicks


### PR DESCRIPTION
Ports f37faf6 to the 1.47 recovery

Fixes #101946

This change already shipped with 1.48.

It is the more conservative fix for #101946