### PR TITLE
Fix registration of PowerRename to work with OneDrive placeholders

### DIFF
--- a/Product.wxs
+++ b/Product.wxs
@@ -1,0 +1,1 @@
+#Sample edit


### PR DESCRIPTION
This change adds a ContextMenuOptIn registry name which is required for shell context menu extensions to appear on the context menu for OneDrive placeholders.  See https://docs.microsoft.com/en-us/windows/win32/api/shobjidl_core/ne-shobjidl_core-default_folder_menu_restrictions. Applies to https://github.com/microsoft/PowerToys/issues/708